### PR TITLE
Fix authentication callback nullability issues

### DIFF
--- a/biometricauth/src/main/java/com/tailoredapps/biometricauth/delegate/marshmallow/MarshmallowAuthManager.kt
+++ b/biometricauth/src/main/java/com/tailoredapps/biometricauth/delegate/marshmallow/MarshmallowAuthManager.kt
@@ -53,17 +53,17 @@ class MarshmallowAuthManager(context: Context) {
                             0,
                             cancellationSignal,
                             object : FingerprintManagerCompat.AuthenticationCallback() {
-                                override fun onAuthenticationError(errMsgId: Int, errString: CharSequence) {
+                                override fun onAuthenticationError(errMsgId: Int, errString: CharSequence?) {
                                     //error, no further callback calls
-                                    emitter.onNext(AuthenticationEvent.Error(errMsgId, errString))
+                                    emitter.onNext(AuthenticationEvent.Error(errMsgId, errString ?: ""))
                                 }
 
-                                override fun onAuthenticationHelp(helpMsgId: Int, helpString: CharSequence) {
-                                    emitter.onNext(AuthenticationEvent.Help(helpMsgId, helpString))
+                                override fun onAuthenticationHelp(helpMsgId: Int, helpString: CharSequence?) {
+                                    emitter.onNext(AuthenticationEvent.Help(helpMsgId, helpString ?: ""))
                                 }
 
-                                override fun onAuthenticationSucceeded(result: FingerprintManagerCompat.AuthenticationResult) {
-                                    emitter.onNext(AuthenticationEvent.Success(result.cryptoObject?.let { BiometricAuth.Crypto(it) }))
+                                override fun onAuthenticationSucceeded(result: FingerprintManagerCompat.AuthenticationResult?) {
+                                    emitter.onNext(AuthenticationEvent.Success(result?.cryptoObject?.let { BiometricAuth.Crypto(it) }))
                                 }
 
                                 override fun onAuthenticationFailed() {

--- a/biometricauth/src/main/java/com/tailoredapps/biometricauth/delegate/pie/PieBiometricAuth.kt
+++ b/biometricauth/src/main/java/com/tailoredapps/biometricauth/delegate/pie/PieBiometricAuth.kt
@@ -123,21 +123,21 @@ class PieBiometricAuth(private val context: Context) : BiometricAuth {
 
     private fun getAuthenticationCallbackForFlowableEmitter(emitter: FlowableEmitter<AuthenticationEvent>): BiometricPrompt.AuthenticationCallback {
         return object : BiometricPrompt.AuthenticationCallback() {
-            override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
+            override fun onAuthenticationError(errorCode: Int, errString: CharSequence?) {
                 if (errorCode == BiometricConstants.Error.USER_CANCELED) {
                     //on the event of user cancelled, do not propagate the original error
                     emitter.onError(BiometricAuthenticationCancelledException())
                 } else {
-                    emitter.onNext(AuthenticationEvent.Error(errorCode, errString))
+                    emitter.onNext(AuthenticationEvent.Error(errorCode, errString ?: ""))
                 }
             }
 
-            override fun onAuthenticationHelp(helpCode: Int, helpString: CharSequence) {
-                emitter.onNext(AuthenticationEvent.Help(helpCode, helpString))
+            override fun onAuthenticationHelp(helpCode: Int, helpString: CharSequence?) {
+                emitter.onNext(AuthenticationEvent.Help(helpCode, helpString ?: ""))
             }
 
-            override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
-                emitter.onNext(AuthenticationEvent.Success(result.cryptoObject?.let { BiometricAuth.Crypto(it) }))
+            override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult?) {
+                emitter.onNext(AuthenticationEvent.Success(result?.cryptoObject?.let { BiometricAuth.Crypto(it) }))
             }
 
             override fun onAuthenticationFailed() {


### PR DESCRIPTION
The methods of the `FingerprintManager.AuthenticationCallback` and `BiometricPrompt.AuthenticationCallback` classes do not have nullability annotations / markers on them, and the `CharSequence` parameters have been treated as non-nullable.

Turns out, on some devices in some situations the `CharSequence` parameter passed can be null.

This PR fixes the implicit non-null force for the parameter and passes along an empty string in that case.