### PR TITLE
Define manifest permissions depending on the api level

### DIFF
--- a/biometricauth/src/main/AndroidManifest.xml
+++ b/biometricauth/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.tailoredapps.biometricauth">
-    <uses-permission android:name="android.permission.USE_FINGERPRINT" />
-    <uses-permission android:name="android.permission.USE_BIOMETRIC" />
+  <uses-permission-sdk-23
+      android:name="android.permission.USE_FINGERPRINT"
+      android:maxSdkVersion="27" />
+  <uses-permission-sdk-23 android:name="android.permission.USE_BIOMETRIC" />
 
 </manifest>


### PR DESCRIPTION
It's considered to be best practice to dynamically set the manifest permissions instead requesting them on all api levels.

I have not fully tested this, but we are currently using a similar approach in our apps (also using your library). Only difference is we didn't set `android:maxSdkVersion` until now, but it should not be a problem, as you use the new biometric API starting from sdk 28.