### PR TITLE
Add AndroidX BiometricPrompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Starting with version `1.2.0`, this library depends on androidx.
 Create a `BiometricAuth` instance:
 
 ```kotlin
-val biometricAuth = BiometricAuth.create(this); // where this is an (AppCompat-)Activity
+val biometricAuth = BiometricAuth.create(this, useAndroidXBiometricPrompt = false) // where this is an (AppCompat-)Activity
 ```
 
 ```kotlin

--- a/app/src/main/java/com/tailoredapps/biometricsample/MainActivity.kt
+++ b/app/src/main/java/com/tailoredapps/biometricsample/MainActivity.kt
@@ -33,7 +33,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private val biometricAuth: BiometricAuth by lazy {
-        BiometricAuth.create(this)
+        BiometricAuth.create(this, useAndroidXBiometricPrompt = false)
     }
 
     private val btnAuthenticate: Button by lazy { findViewById<Button>(R.id.btn_authenticate) }

--- a/biometricauth/api/biometricauth.api
+++ b/biometricauth/api/biometricauth.api
@@ -7,6 +7,7 @@ public abstract interface class com/tailoredapps/biometricauth/BiometricAuth {
 }
 
 public final class com/tailoredapps/biometricauth/BiometricAuth$Companion {
+	public final fun create (Landroidx/appcompat/app/AppCompatActivity;)Lcom/tailoredapps/biometricauth/BiometricAuth;
 	public final fun create (Landroidx/appcompat/app/AppCompatActivity;Z)Lcom/tailoredapps/biometricauth/BiometricAuth;
 	public static synthetic fun create$default (Lcom/tailoredapps/biometricauth/BiometricAuth$Companion;Landroidx/appcompat/app/AppCompatActivity;ZILjava/lang/Object;)Lcom/tailoredapps/biometricauth/BiometricAuth;
 }

--- a/biometricauth/api/biometricauth.api
+++ b/biometricauth/api/biometricauth.api
@@ -7,8 +7,8 @@ public abstract interface class com/tailoredapps/biometricauth/BiometricAuth {
 }
 
 public final class com/tailoredapps/biometricauth/BiometricAuth$Companion {
-	public final fun create (Landroidx/appcompat/app/AppCompatActivity;)Lcom/tailoredapps/biometricauth/BiometricAuth;
 	public final fun create (Landroidx/appcompat/app/AppCompatActivity;Z)Lcom/tailoredapps/biometricauth/BiometricAuth;
+	public static synthetic fun create$default (Lcom/tailoredapps/biometricauth/BiometricAuth$Companion;Landroidx/appcompat/app/AppCompatActivity;ZILjava/lang/Object;)Lcom/tailoredapps/biometricauth/BiometricAuth;
 }
 
 public final class com/tailoredapps/biometricauth/BiometricAuth$Crypto : java/io/Serializable {

--- a/biometricauth/api/biometricauth.api
+++ b/biometricauth/api/biometricauth.api
@@ -8,10 +8,12 @@ public abstract interface class com/tailoredapps/biometricauth/BiometricAuth {
 
 public final class com/tailoredapps/biometricauth/BiometricAuth$Companion {
 	public final fun create (Landroidx/appcompat/app/AppCompatActivity;)Lcom/tailoredapps/biometricauth/BiometricAuth;
+	public final fun create (Landroidx/appcompat/app/AppCompatActivity;Z)Lcom/tailoredapps/biometricauth/BiometricAuth;
 }
 
 public final class com/tailoredapps/biometricauth/BiometricAuth$Crypto : java/io/Serializable {
 	public fun <init> (Landroid/hardware/biometrics/BiometricPrompt$CryptoObject;)V
+	public fun <init> (Landroidx/biometric/BiometricPrompt$CryptoObject;)V
 	public fun <init> (Landroidx/core/hardware/fingerprint/FingerprintManagerCompat$CryptoObject;)V
 	public fun <init> (Ljava/security/Signature;)V
 	public fun <init> (Ljavax/crypto/Cipher;)V

--- a/biometricauth/build.gradle
+++ b/biometricauth/build.gradle
@@ -28,6 +28,8 @@ dependencies {
     api 'com.google.android.material:material:1.1.0'
     api 'androidx.constraintlayout:constraintlayout:1.1.3'
 
+    api 'androidx.biometric:biometric:1.0.1'
+
 
     api 'io.reactivex.rxjava2:rxjava:2.2.19'
     api 'io.reactivex.rxjava2:rxandroid:2.1.1'

--- a/biometricauth/src/main/java/com/tailoredapps/biometricauth/BiometricAuth.kt
+++ b/biometricauth/src/main/java/com/tailoredapps/biometricauth/BiometricAuth.kt
@@ -47,7 +47,7 @@ interface BiometricAuth {
             val versionCode = Build.VERSION.SDK_INT
             return when {
                 versionCode >= Build.VERSION_CODES.P -> PieBiometricAuth(activity)
-                versionCode >= Build.VERSION_CODES.M ->  MarshmallowBiometricAuth(activity)
+                versionCode >= Build.VERSION_CODES.M -> MarshmallowBiometricAuth(activity)
                 else -> LegacyBiometricAuth()
             }
         }

--- a/biometricauth/src/main/java/com/tailoredapps/biometricauth/BiometricAuth.kt
+++ b/biometricauth/src/main/java/com/tailoredapps/biometricauth/BiometricAuth.kt
@@ -40,32 +40,15 @@ interface BiometricAuth {
          * Create a [BiometricAuth] instance targeting the devices' version-code (taken from [Build.VERSION.SDK_INT]).
          *
          * @param activity the current activity (as [AppCompatActivity]) which requests the authentication.
-         *
-         * @return an instance of [BiometricAuth], which targets the devices' SDK version.
-         */
-        fun create(activity: AppCompatActivity): BiometricAuth {
-            val versionCode = Build.VERSION.SDK_INT
-            return when {
-                versionCode >= Build.VERSION_CODES.P -> PieBiometricAuth(activity)
-                versionCode >= Build.VERSION_CODES.M -> MarshmallowBiometricAuth(activity)
-                else -> LegacyBiometricAuth()
-            }
-        }
-
-        /**
-         * Create a [BiometricAuth] instance targeting the devices' version-code (taken from [Build.VERSION.SDK_INT]).
-         *
-         * @param activity the current activity (as [AppCompatActivity]) which requests the
-         * authentication.
          * @param useAndroidXBiometricPrompt Whether on pre android 10 devices the [AndroidXBiometricAuth]
          * should be used in favor of the custom implementation [MarshmallowBiometricAuth].
          * The main difference here is, that the backport is not necessarily shown as
-         * bottom-navigation-sheet, whereas the [MarshmallowBiometricAuth] is always shown as a
-         * bottom-sheet.
+         * bottom-sheet-dialog, whereas the [MarshmallowBiometricAuth] is always shown as a
+         * bottom-sheet-dialog.
          *
          * @return an instance of [BiometricAuth], which targets the devices' SDK version.
          */
-        fun create(activity: AppCompatActivity, useAndroidXBiometricPrompt: Boolean): BiometricAuth {
+        fun create(activity: AppCompatActivity, useAndroidXBiometricPrompt: Boolean = false): BiometricAuth {
             val versionCode = Build.VERSION.SDK_INT
             return when {
                 versionCode >= Build.VERSION_CODES.P -> PieBiometricAuth(activity)

--- a/biometricauth/src/main/java/com/tailoredapps/biometricauth/BiometricAuth.kt
+++ b/biometricauth/src/main/java/com/tailoredapps/biometricauth/BiometricAuth.kt
@@ -37,6 +37,17 @@ interface BiometricAuth {
     companion object {
 
         /**
+         * **Deprecated**: Use the method with the optional Boolean parameter 'useAndroidXBiometricPrompt'.
+         */
+        @Deprecated(
+                message = "This method is solely kept for binary compatibility reasons. Use create() with two parameters instead.",
+                replaceWith = ReplaceWith("BiometricAuth.create(activity, useAndroidXBiometricPrompt = false)")
+        )
+        fun create(activity: AppCompatActivity): BiometricAuth {
+            return create(activity = activity, useAndroidXBiometricPrompt = false)
+        }
+
+        /**
          * Create a [BiometricAuth] instance targeting the devices' version-code (taken from [Build.VERSION.SDK_INT]).
          *
          * @param activity the current activity (as [AppCompatActivity]) which requests the authentication.

--- a/biometricauth/src/main/java/com/tailoredapps/biometricauth/delegate/androidxlegacy/AndroidXBiometricAuth.kt
+++ b/biometricauth/src/main/java/com/tailoredapps/biometricauth/delegate/androidxlegacy/AndroidXBiometricAuth.kt
@@ -1,0 +1,133 @@
+package com.tailoredapps.biometricauth.delegate.androidxlegacy
+
+import android.annotation.TargetApi
+import android.content.Context
+import androidx.annotation.RestrictTo
+import androidx.biometric.BiometricPrompt
+import androidx.core.hardware.fingerprint.FingerprintManagerCompat
+import androidx.fragment.app.FragmentActivity
+import com.tailoredapps.biometricauth.BiometricAuth
+import com.tailoredapps.biometricauth.BiometricAuthenticationCancelledException
+import com.tailoredapps.biometricauth.BiometricAuthenticationException
+import com.tailoredapps.biometricauth.BiometricConstants
+import com.tailoredapps.biometricauth.delegate.AuthenticationEvent
+import io.reactivex.*
+import java.util.concurrent.Executor
+
+@TargetApi(28)
+@RestrictTo(RestrictTo.Scope.LIBRARY)
+internal class AndroidXBiometricAuth(
+        private val context: Context,
+        private val fragmentActivity: FragmentActivity
+) : BiometricAuth {
+
+    constructor(activity: FragmentActivity) : this(activity, activity)
+
+    private val fingerprintManagerCompat: FingerprintManagerCompat = FingerprintManagerCompat.from(context)
+
+    override val hasFingerprintHardware: Boolean
+        get() = fingerprintManagerCompat.isHardwareDetected
+
+    override val hasFingerprintsEnrolled: Boolean
+        get() = fingerprintManagerCompat.hasEnrolledFingerprints()
+
+
+    private fun internalAuthenticate(cryptoObject: BiometricAuth.Crypto?, title: CharSequence,
+                                     subtitle: CharSequence?, description: CharSequence?,
+                                     negativeButtonText: CharSequence): Maybe<BiometricAuth.Crypto> {
+        return Flowable
+                .create<AuthenticationEvent>({ emitter ->
+                    val executor = Executor { it.run() }
+
+                    val promptInfo = BiometricPrompt.PromptInfo.Builder()
+                            .setTitle(title)
+                            .setSubtitle(subtitle)
+                            .setDescription(description)
+                            .setNegativeButtonText(negativeButtonText)
+                            .build()
+
+                    val biometricPrompt = BiometricPrompt(fragmentActivity, executor, getAuthenticationCallbackForFlowableEmitter(emitter))
+
+                    emitter.setCancellable { biometricPrompt.cancelAuthentication() }
+
+                    val convertedCryptoObject = cryptoObject?.toCryptoObject()
+                    if (convertedCryptoObject != null) {
+                        biometricPrompt.authenticate(promptInfo, convertedCryptoObject)
+                    } else {
+                        biometricPrompt.authenticate(promptInfo)
+                    }
+                }, BackpressureStrategy.LATEST)
+                .filter { event -> event is AuthenticationEvent.Success || event is AuthenticationEvent.Error }
+                .firstOrError()
+                .onErrorResumeNext { throwable ->
+                    if (throwable is NoSuchElementException) {
+                        Single.error(BiometricAuthenticationCancelledException())
+                    } else {
+                        Single.error(throwable)
+                    }
+                }
+                .flatMapMaybe { event ->
+                    when (event) {
+                        is AuthenticationEvent.Success -> {
+                            if (event.crypto != null) {
+                                Maybe.just(event.crypto)
+                            } else {
+                                Maybe.empty()
+                            }
+                        }
+                        is AuthenticationEvent.Error -> Maybe.error(BiometricAuthenticationException(
+                                errorMessageId = event.messageId, errorString = event.message
+                        ))
+                        else -> Maybe.error(BiometricAuthenticationException(
+                                errorMessageId = 0,
+                                errorString = ""
+                        ))
+                    }
+                }
+    }
+
+    override fun authenticate(cryptoObject: BiometricAuth.Crypto, title: CharSequence, subtitle: CharSequence?, description: CharSequence?,
+                              prompt: CharSequence, notRecognizedErrorText: CharSequence,
+                              negativeButtonText: CharSequence): Single<BiometricAuth.Crypto> {
+        return internalAuthenticate(cryptoObject, title, subtitle, description, negativeButtonText).toSingle()
+    }
+
+
+    override fun authenticate(title: CharSequence, subtitle: CharSequence?, description: CharSequence?,
+                              prompt: CharSequence, notRecognizedErrorText: CharSequence,
+                              negativeButtonText: CharSequence): Completable {
+        return internalAuthenticate(null, title, subtitle, description, negativeButtonText).ignoreElement()
+    }
+
+
+    private fun BiometricAuth.Crypto.toCryptoObject(): BiometricPrompt.CryptoObject? {
+        return when {
+            this.signature != null -> BiometricPrompt.CryptoObject(this.signature)
+            this.cipher != null -> BiometricPrompt.CryptoObject(this.cipher)
+            this.mac != null -> BiometricPrompt.CryptoObject(this.mac)
+            else -> null
+        }
+    }
+
+    private fun getAuthenticationCallbackForFlowableEmitter(emitter: FlowableEmitter<AuthenticationEvent>): BiometricPrompt.AuthenticationCallback {
+        return object : BiometricPrompt.AuthenticationCallback() {
+            override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
+                if (errorCode == BiometricConstants.Error.USER_CANCELED) {
+                    //on the event of user cancelled, do not propagate the original error
+                    emitter.onError(BiometricAuthenticationCancelledException())
+                } else {
+                    emitter.onNext(AuthenticationEvent.Error(errorCode, errString))
+                }
+            }
+
+            override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
+                emitter.onNext(AuthenticationEvent.Success(result.cryptoObject?.let { BiometricAuth.Crypto(it) }))
+            }
+
+            override fun onAuthenticationFailed() {
+                emitter.onNext(AuthenticationEvent.Failed)
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Adds the androidx BiometricPrompt to be used optionally instead of the custom implemented backport.

Main difference in those two is, that the androids BiometricPrompt is not necessarly shown as BottomNavigationSheet.