### PR TITLE
Replace api with implementation for biometric dependency

### DIFF
--- a/biometricauth/build.gradle
+++ b/biometricauth/build.gradle
@@ -28,8 +28,7 @@ dependencies {
     api 'com.google.android.material:material:1.1.0'
     api 'androidx.constraintlayout:constraintlayout:1.1.3'
 
-    api 'androidx.biometric:biometric:1.0.1'
-
+    implementation 'androidx.biometric:biometric:1.0.1'
 
     api 'io.reactivex.rxjava2:rxjava:2.2.19'
     api 'io.reactivex.rxjava2:rxandroid:2.1.1'


### PR DESCRIPTION
Our app update was declined due duplicate permission with different maxSdkVersions. We used your last SDK version 1.3.0. After some investigation I found the problem. 

Merged manifest of sample app:
<img src="https://user-images.githubusercontent.com/7870154/92446723-8838ff00-f1b6-11ea-8c57-51d601cf9313.png" width="300">

As you can see the fingerprint and biometric permissions are doubled.

Solution:
Change biometric dependency from api to implementation. There is no reason to export the dependency to other modules

Result:
<img src="https://user-images.githubusercontent.com/7870154/92446719-8707d200-f1b6-11ea-8df9-71c712c58bab.png" width="300">